### PR TITLE
Add funding.yml file

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,1 @@
+github: danieltj27


### PR DESCRIPTION
Add `funding.yml` file to repository to enable GitHub sponsor button.